### PR TITLE
Update appy.js

### DIFF
--- a/appy.js
+++ b/appy.js
@@ -527,7 +527,7 @@ module.exports.listen = function(host) {
 
   var setHost = '0.0.0.0';
 
-  if(host !==undefined || host !==''){
+  if(host !==undefined || host ===''){
       setHost = host;
   }
 


### PR DESCRIPTION
Even though there is code in place to make the port selection of the application highly configurable, there needs to be a way to define the host to which the process binds to, in the same configurable manner.

For example when exposing to port :80 via nginx you don't want the site to be available on :3000 as well. This could be solved with a firewall rule, but then this may not be available to the developer deploying the application.
