### PR TITLE
Accept address and port as params on listen

### DIFF
--- a/appy.js
+++ b/appy.js
@@ -741,7 +741,7 @@ module.exports.listen = function(address, port) {
   if (process.env.PORT) {
     port = process.env.PORT;
   } else {
-    if (isNaN(port) === true) {
+    if (!port) {
       try {
         // Stagecoach option
         port = fs.readFileSync(options.rootDir + '/data/port', 'UTF-8').replace(/\s+$/, '');

--- a/appy.js
+++ b/appy.js
@@ -721,6 +721,9 @@ function appBootstrap(callback) {
 }
 
 module.exports.listen = function(address, port) {
+  address = address || options.address;
+  port = port || options.port;
+
   // Heroku
   if (process.env.ADDRESS) {
     address = process.env.ADDRESS;
@@ -738,7 +741,7 @@ module.exports.listen = function(address, port) {
   if (process.env.PORT) {
     port = process.env.PORT;
   } else {
-    if (port === undefined || port === '') {
+    if (isNaN(port) === true) {
       try {
         // Stagecoach option
         port = fs.readFileSync(options.rootDir + '/data/port', 'UTF-8').replace(/\s+$/, '');

--- a/sample.js
+++ b/sample.js
@@ -67,7 +67,7 @@ appy.bootstrap({
     // Or more than one index:
     // [ { name: 'posts', indexes: [ { fields: { { title: 1 } } }, ... ] } ]
   },
-  host: process.env.HOST || null,
+  address: process.env.ADDRESS || null,
   port: process.env.PORT || null,
 
   // This is where your code goes! Add routes, do anything else you want to do,

--- a/sample.js
+++ b/sample.js
@@ -67,6 +67,8 @@ appy.bootstrap({
     // Or more than one index:
     // [ { name: 'posts', indexes: [ { fields: { { title: 1 } } }, ... ] } ]
   },
+  host: process.env.HOST || null,
+  port: process.env.PORT || null,
 
   // This is where your code goes! Add routes, do anything else you want to do,
   // then call appy.listen


### PR DESCRIPTION
As of now appy only grabs the address and port from file locations. Updated the `module.exports.listen` function to accept an address and port. If one is not provided then it will use set defaults after checking for the files that hold the address and port.